### PR TITLE
Update pack to version 9

### DIFF
--- a/Slimefun Beautified/pack.mcmeta
+++ b/Slimefun Beautified/pack.mcmeta
@@ -1,6 +1,6 @@
 {
    "pack":{
-      "pack_format":8,
+      "pack_format":9,
       "description":"§a§lSlimefun §5§lB§d§le§9§la§1§lu§3§lt§b§li§a§lf§e§li§6§le§c§ld \n§eUnknown §7- (v1.0)"
    }
 }


### PR DESCRIPTION
Update `pack.mcmeta` to version 9

- Dismisses "This pack was made for an older version of Minecraft"
- Updated date in pack description

